### PR TITLE
fixed python3.9 package name in spark docker files

### DIFF
--- a/spark/spark-local/setup-master/Dockerfile
+++ b/spark/spark-local/setup-master/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH $SPARK_DIR/bin:$SPARK_DIR/sbin:$PATH
 
 ADD setup/spark-${SPARK_VERSION}-bin-hadoop3.2.tgz /opt
 RUN apt-get update && apt-get -y install bash 
-RUN apt-get -y install python3=3.9
+RUN apt-get -y install python3.9
 
 RUN mv /opt/spark-${SPARK_VERSION}-bin-hadoop3.2 ${SPARK_DIR}
 

--- a/spark/spark-local/setup-worker/Dockerfile
+++ b/spark/spark-local/setup-worker/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH $SPARK_DIR/bin:$SPARK_DIR/sbin:$PATH
 
 ADD setup/spark-${SPARK_VERSION}-bin-hadoop3.2.tgz /opt
 RUN apt-get update && apt-get -y install bash 
-RUN apt-get -y install python3=3.9
+RUN apt-get -y install python3.9
 
 RUN mv /opt/spark-${SPARK_VERSION}-bin-hadoop3.2 ${SPARK_DIR}
 # add custom start script


### PR DESCRIPTION
Il docker file di spark non funzionava perché non riusciva ad eseguire il comando 
`apt-get install python3=3.9`
Si potrebbe ovviare al problema utilizzando direttamente il nome del pacchetto corrispondente alla versione 3.9
`apt-get install python3.9`